### PR TITLE
[Hunyo] Enhance token handling and flashcard choices support

### DIFF
--- a/Controllers/FlashcardsController.cs
+++ b/Controllers/FlashcardsController.cs
@@ -25,9 +25,9 @@ namespace ScholarMeServer.Controllers
         }
 
         [HttpGet("decks/{flashcardDeckId:int}/cards")]
-        public async Task<IActionResult> GetFlashcardsByDeckId([FromRoute] int flashcardDeckId)
+        public async Task<IActionResult> GetFlashcardsByDeckId([FromRoute] int flashcardDeckId, [FromQuery] bool choices = false)
         {
-            var flashcards = await _flashcardService.GetFlashcardsByDeckId(flashcardDeckId);
+            var flashcards = await _flashcardService.GetFlashcardsByDeckId(flashcardDeckId, choices);
             return Ok(flashcards);
         }
 

--- a/DTO/Flashcard/FlashcardReadOnlyDto.cs
+++ b/DTO/Flashcard/FlashcardReadOnlyDto.cs
@@ -1,4 +1,5 @@
 ﻿using ScholarMeServer.DTO.FlashcardChoice;
+using System.Text.Json.Serialization;
 
 namespace ScholarMeServer.DTO.Flashcard
 {
@@ -14,5 +15,8 @@ namespace ScholarMeServer.DTO.Flashcard
         public DateTime CreatedAt { get; set; }
 
         public DateTime UpdatedAt { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<FlashcardChoiceReadOnlyDto>? Choices { get; set; }
     }
 }

--- a/DTO/FlashcardChoice/FlashcardChoiceReadOnlyDto.cs
+++ b/DTO/FlashcardChoice/FlashcardChoiceReadOnlyDto.cs
@@ -1,10 +1,13 @@
-﻿namespace ScholarMeServer.DTO.FlashcardChoice
+﻿using System.Text.Json.Serialization;
+
+namespace ScholarMeServer.DTO.FlashcardChoice
 {
     public class FlashcardChoiceReadOnlyDto
     {
         public int Id { get; set; }
 
-        public int FlashcardId { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public int? FlashcardId { get; set; }
 
         public string Choice { get; set; }
 

--- a/DTO/RefreshToken/RefreshTokenCreateDto.cs
+++ b/DTO/RefreshToken/RefreshTokenCreateDto.cs
@@ -1,7 +1,0 @@
-﻿namespace ScholarMeServer.DTO
-{
-    public class RefreshTokenCreateDto
-    {
-        public string Token { get; set; } = string.Empty;
-    }
-}

--- a/DTO/RefreshToken/RefreshTokenRequestDto.cs
+++ b/DTO/RefreshToken/RefreshTokenRequestDto.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ScholarMeServer.DTO.RefreshToken
+{
+    public class RefreshTokenRequestDto
+    {
+        [Required]
+        public string RefreshToken { get; set; }
+    }
+}

--- a/Migrations/20241214111036_init.Designer.cs
+++ b/Migrations/20241214111036_init.Designer.cs
@@ -230,7 +230,7 @@ namespace ScholarMeServer.Migrations
                     b.Property<DateTime>("ExpiresOnUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("Token")
+                    b.Property<string>("RefreshToken")
                         .IsRequired()
                         .HasColumnType("text");
 

--- a/Migrations/ScholarMeDbContextModelSnapshot.cs
+++ b/Migrations/ScholarMeDbContextModelSnapshot.cs
@@ -227,7 +227,7 @@ namespace ScholarMeServer.Migrations
                     b.Property<DateTime>("ExpiresOnUtc")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<string>("Token")
+                    b.Property<string>("RefreshToken")
                         .IsRequired()
                         .HasColumnType("text");
 

--- a/Repository/FlashcardInfo/FlashcardRepository.cs
+++ b/Repository/FlashcardInfo/FlashcardRepository.cs
@@ -14,9 +14,16 @@ namespace ScholarMeServer.Repository.FlashcardInfo
             await _scholarmeDbContext.SaveChangesAsync();
         }
 
-        public async Task<List<Flashcard>> GetFlashcardsByDeckId(int flashcardDeckId)
+        public async Task<List<Flashcard>> GetFlashcardsByDeckId(int flashcardDeckId, bool choices)
         {
-            var flashcards = await _scholarmeDbContext.Set<Flashcard>().Where(f => f.FlashcardDeckId == flashcardDeckId).ToListAsync();
+            IQueryable<Flashcard> query = _scholarmeDbContext.Set<Flashcard>().Where(f => f.FlashcardDeckId == flashcardDeckId);
+
+            if (choices)
+            {
+                query = query.Include(f => f.Choices);
+            }
+
+            var flashcards = await query.ToListAsync();
             return flashcards;
         }
 

--- a/Repository/FlashcardInfo/IFlashcardRepository.cs
+++ b/Repository/FlashcardInfo/IFlashcardRepository.cs
@@ -5,7 +5,7 @@ namespace ScholarMeServer.Repository.FlashcardInfo
     public interface IFlashcardRepository
     {
         public Task AddFlashcard(Flashcard flashcard);
-        public Task<List<Flashcard>> GetFlashcardsByDeckId(int flashcardDeckId);
+        public Task<List<Flashcard>> GetFlashcardsByDeckId(int flashcardDeckId, bool choices);
         public Task<Flashcard?> GetFlashcardById(int flashcardId);
         public Task DeleteFlashcard(Flashcard flashcard);
         public Task SaveFlashcard(Flashcard flashcard);

--- a/Repository/UserAccountInfo/UserAccountInfoRepository.cs
+++ b/Repository/UserAccountInfo/UserAccountInfoRepository.cs
@@ -49,7 +49,7 @@ namespace ScholarMeServer.Repository.UserAccountInfo
         public async Task SaveRefreshToken(RefreshToken refreshToken)
         {
             var existingToken = await _scholarmeDbContext.Set<RefreshToken>()
-                .SingleOrDefaultAsync(rt => rt.Token == refreshToken.Token);
+                .SingleOrDefaultAsync(rt => rt.Id == refreshToken.Id);
 
             if (existingToken == null)
             {

--- a/Services/FlashcardInfo/FlashcardService.cs
+++ b/Services/FlashcardInfo/FlashcardService.cs
@@ -36,9 +36,9 @@ namespace ScholarMeServer.Services.FlashcardInfo
             };
         }
 
-        public async Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(int flashcardDeckId)
+        public async Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(int flashcardDeckId, bool choices)
         {
-            var flashcards = await _flashcardRepository.GetFlashcardsByDeckId(flashcardDeckId);
+            var flashcards = await _flashcardRepository.GetFlashcardsByDeckId(flashcardDeckId, choices);
 
             return flashcards.Select(f => new FlashcardReadOnlyDto
             {
@@ -47,6 +47,15 @@ namespace ScholarMeServer.Services.FlashcardInfo
                 Question = f.Question,
                 CreatedAt = f.CreatedAt,
                 UpdatedAt = f.UpdatedAt,
+                Choices = choices ? f.Choices.Select(c => new FlashcardChoiceReadOnlyDto
+                {
+                    Id = c.Id,
+                    FlashcardId = null,
+                    Choice = c.Choice,
+                    IsAnswer = c.IsAnswer,
+                    CreatedAt = c.CreatedAt,
+                    UpdatedAt = c.UpdatedAt,
+                }).ToList() : null
             }).ToList();
         }
 

--- a/Services/FlashcardInfo/IFlashcardService.cs
+++ b/Services/FlashcardInfo/IFlashcardService.cs
@@ -5,7 +5,7 @@ namespace ScholarMeServer.Services.FlashcardInfo
     public interface IFlashcardService
     {
         public Task<FlashcardReadOnlyDto> CreateFlashcard(int flashcardDeckId, FlashcardCreateDto flashcardDto);
-        public Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(int flashcardDeckId);
+        public Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(int flashcardDeckId, bool choices);
         public Task<FlashcardReadOnlyDto> GetFlashcardById(int flashcardId);
         public Task<FlashcardReadOnlyDto> UpdateFlashcard(int flashcardId, FlashcardUpdateDto flashcardDto);
         public Task DeleteFlashcard(int flashcardId);

--- a/Services/UserAccountInfo/IUserAccountInfoService.cs
+++ b/Services/UserAccountInfo/IUserAccountInfoService.cs
@@ -13,6 +13,6 @@ namespace ScholarMeServer.Services.UserAccountInfo
         public Task UpdateUserPassword(int userAccountId, UserAccountChangePasswordDto userAccountDto);
         public Task<UserAccountReadOnlyDto> GetUserById(int userId);
         public Task<RefreshTokenReadOnly> CreateRefreshToken(int userId, string token, DateTime expires);
-        public Task UpdateRefreshToken(int userId, string oldToken, string newToken, DateTime expires);
+        public Task<RefreshTokenReadOnly> UpdateRefreshToken(string oldToken, string newToken, DateTime expires);
     }
 }

--- a/Services/UserAccountInfo/UserAccountInfoService.cs
+++ b/Services/UserAccountInfo/UserAccountInfoService.cs
@@ -185,23 +185,31 @@ namespace ScholarMeServer.Services.UserAccountInfo
             };
         }
 
-        public async Task UpdateRefreshToken(int userId, string oldToken, string newToken, DateTime expires)
+        public async Task<RefreshTokenReadOnly> UpdateRefreshToken(string oldToken, string newToken, DateTime expires)
         {
             RefreshToken? refreshToken = await _userAccountInfoRepository.GetRefreshToken(oldToken);
 
             if (refreshToken == null)
             {
-                throw new HttpResponseException((int)HttpStatusCode.Unauthorized, "Refresh token not found");
+                throw new HttpResponseException((int)HttpStatusCode.Unauthorized, "INVALID_REFRESH_TOKEN");
             }
 
             if (refreshToken.ExpiresOnUtc < DateTime.UtcNow)
             {
-                throw new HttpResponseException((int)HttpStatusCode.Unauthorized, "The refresh token has expired");
+                throw new HttpResponseException((int)HttpStatusCode.Unauthorized, "REFRESH_TOKEN_EXPIRED");
             }
 
             refreshToken.Token = newToken;
 
             await _userAccountInfoRepository.SaveRefreshToken(refreshToken);
+
+            return new RefreshTokenReadOnly()
+            {
+                Id = refreshToken.Id,
+                UserAccountId = refreshToken.UserAccountId,
+                Token = refreshToken.Token,
+                ExpiresOnUtc = refreshToken.ExpiresOnUtc,
+            };
         }
     }
 }

--- a/Utilities/JwtService.cs
+++ b/Utilities/JwtService.cs
@@ -51,27 +51,4 @@ public class JwtService
             return Convert.ToBase64String(randomNumber);
         }
     }
-
-    public ClaimsPrincipal GetPrincipalFromExpiredToken(string token)
-    {
-        var tokenValidationParameters = new TokenValidationParameters
-        {
-            ValidateAudience = false,
-            ValidateIssuer = false,
-            ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(_configuration["Jwt:Key"]!)),
-            ValidateLifetime = false
-        };
-
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var principal = tokenHandler.ValidateToken(token, tokenValidationParameters, out SecurityToken securityToken);
-
-        if (securityToken is not JwtSecurityToken jwtSecurityToken ||
-            !jwtSecurityToken.Header.Alg.Equals(SecurityAlgorithms.HmacSha256, StringComparison.InvariantCultureIgnoreCase))
-        {
-            throw new SecurityTokenException("Invalid token");
-        }
-
-        return principal;
-    }
 }

--- a/Utilities/Middlewares/ExceptionHandlerMiddleware.cs
+++ b/Utilities/Middlewares/ExceptionHandlerMiddleware.cs
@@ -50,6 +50,16 @@ namespace ScholarMeServer.Utilities.Middlewares
                 Instance = context.Request.Path
             };
 
+            // Check for the WWW-Authenticate header to determine if the token is invalid
+            if (context.Response.Headers.ContainsKey("WWW-Authenticate"))
+            {
+                var wwwAuthenticateHeader = context.Response.Headers["WWW-Authenticate"].ToString();
+                if (wwwAuthenticateHeader.Contains("invalid_token"))
+                {
+                    problemDetails.Detail = "INVALID_ACCESS_TOKEN";
+                }
+            }
+
             return context.Response.WriteAsJsonAsync(problemDetails);
         }
 


### PR DESCRIPTION
- Updated `GetFlashcardsByDeckId` in `FlashcardsController.cs` to accept `choices` parameter.
- Refactored `RefreshToken` in `UserAccountsController.cs` to use `RefreshTokenRequestDto` and validate tokens.
- Added `Choices` property to `FlashcardReadOnlyDto` and conditional serialization.
- Updated `FlashcardChoiceReadOnlyDto` to conditionally serialize `FlashcardId`.
- Replaced `RefreshTokenCreateDto` with `RefreshTokenRequestDto`.
- Renamed `Token` to `RefreshToken` in the database schema.
- Added but commented out rate limiting middleware in `Program.cs`.
- Set `ClockSkew` to zero in `JwtBearer` setup in `Program.cs`.
- Updated Swagger JWT description to "Enter your JWT Access RefreshToken".
- Enhanced `GetFlashcardsByDeckId` in `FlashcardRepository.cs` and `FlashcardService.cs` to handle `choices` parameter.
- Updated `UpdateRefreshToken` in `UserAccountInfoService.cs` to return `RefreshTokenReadOnly` and handle exceptions.
- Modified `JwtService` to change token validity to seconds and removed `GetPrincipalFromExpiredToken`.
- Enhanced `ExceptionHandlerMiddleware` to check `WWW-Authenticate` header for invalid tokens.