### PR TITLE
[Hunyo] Add optional params for detailed API responses

### DIFF
--- a/Controllers/FlashcardDecksController.cs
+++ b/Controllers/FlashcardDecksController.cs
@@ -35,9 +35,9 @@ namespace ScholarMeServer.Controllers
         }
 
         [HttpGet("{flashcardDeckId:Guid}", Name = "GetFlashcardDeckById")]
-        public async Task<IActionResult> GetFlashcardDeckById([FromRoute] Guid flashcardDeckId)
+        public async Task<IActionResult> GetFlashcardDeckById([FromRoute] Guid flashcardDeckId, [FromQuery] bool includeFlashcards = false)
         {
-            var flashcardDeck = await _flashcardDeckService.GetFlashcardDeckById(flashcardDeckId);
+            var flashcardDeck = await _flashcardDeckService.GetFlashcardDeckById(flashcardDeckId, includeFlashcards);
             return Ok(flashcardDeck);
         }
 

--- a/Controllers/FlashcardsController.cs
+++ b/Controllers/FlashcardsController.cs
@@ -25,9 +25,9 @@ namespace ScholarMeServer.Controllers
         }
 
         [HttpGet("decks/{flashcardDeckId:Guid}/cards")]
-        public async Task<IActionResult> GetFlashcardsByDeckId([FromRoute] Guid flashcardDeckId, [FromQuery] bool choices = false)
+        public async Task<IActionResult> GetFlashcardsByDeckId([FromRoute] Guid flashcardDeckId, [FromQuery] bool includeChoices = false)
         {
-            var flashcards = await _flashcardService.GetFlashcardsByDeckId(flashcardDeckId, choices);
+            var flashcards = await _flashcardService.GetFlashcardsByDeckId(flashcardDeckId, includeChoices);
             return Ok(flashcards);
         }
 

--- a/DTO/Flashcard/FlashcardReadOnlyDto.cs
+++ b/DTO/Flashcard/FlashcardReadOnlyDto.cs
@@ -8,7 +8,8 @@ namespace ScholarMeServer.DTO.Flashcard
     {
         public Guid Id { get; set; }
 
-        public Guid FlashcardSetId { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Guid? FlashcardSetId { get; set; }
 
         public string Question { get; set; }
 

--- a/DTO/FlashcardDeck/FlashcardDeckReadOnlyDto.cs
+++ b/DTO/FlashcardDeck/FlashcardDeckReadOnlyDto.cs
@@ -1,4 +1,5 @@
 ﻿using ScholarMeServer.DTO.Flashcard;
+using ScholarMeServer.DTO.FlashcardChoice;
 using ScholarMeServer.DTO.UserAccount;
 using System.Text.Json.Serialization;
 
@@ -9,7 +10,8 @@ namespace ScholarMeServer.DTO.FlashcardDeck
     {
         public Guid Id { get; set; }
 
-        public Guid UserAccountId { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public Guid? UserAccountId { get; set; }
 
         public string Title { get; set; }
 
@@ -18,5 +20,8 @@ namespace ScholarMeServer.DTO.FlashcardDeck
         public DateTime CreatedAt { get; set; }
 
         public DateTime UpdatedAt { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public List<FlashcardReadOnlyDto>? Flashcards { get; set; }
     }
 }

--- a/Repository/FlashcardDeckInfo/FlashcardDeckRepository.cs
+++ b/Repository/FlashcardDeckInfo/FlashcardDeckRepository.cs
@@ -20,9 +20,16 @@ namespace ScholarMeServer.Repository.FlashcardDeckInfo
             return flashcardDecks;
         }
 
-        public async Task<FlashcardDeck?> GetFlashcardDeckById(Guid flashcardDeckId)
+        public async Task<FlashcardDeck?> GetFlashcardDeckById(Guid flashcardDeckId, bool includeFlashcards = true)
         {
-            var flashcardDeck = await _scholarmeDbContext.Set<FlashcardDeck>().FindAsync(flashcardDeckId);
+            IQueryable<FlashcardDeck> query = _scholarmeDbContext.Set<FlashcardDeck>();
+
+            if (includeFlashcards)
+            {
+                query = query.Include(deck => deck.Flashcards);
+            }
+
+            var flashcardDeck = await query.FirstOrDefaultAsync(deck => deck.Id == flashcardDeckId);
             return flashcardDeck;
         }
 

--- a/Repository/FlashcardDeckInfo/IFlashcardDeckRepository.cs
+++ b/Repository/FlashcardDeckInfo/IFlashcardDeckRepository.cs
@@ -6,7 +6,7 @@ namespace ScholarMeServer.Repository.FlashcardDeckInfo
     {
         public Task AddFlashcardDeck(FlashcardDeck flashcardDeck);
         public Task<List<FlashcardDeck>> GetFlashcardDecksByUserId(Guid userAccountId);
-        public Task<FlashcardDeck?> GetFlashcardDeckById(Guid flashcardDeckId);
+        public Task<FlashcardDeck?> GetFlashcardDeckById(Guid flashcardDeckId, bool includeFlashcards = true);
         public Task SaveFlashcardDeck(FlashcardDeck flashcardDeck);
         public Task DeleteFlashcardDeck(FlashcardDeck flashcardDeck);
 

--- a/Repository/FlashcardInfo/FlashcardRepository.cs
+++ b/Repository/FlashcardInfo/FlashcardRepository.cs
@@ -14,11 +14,11 @@ namespace ScholarMeServer.Repository.FlashcardInfo
             await _scholarmeDbContext.SaveChangesAsync();
         }
 
-        public async Task<List<Flashcard>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool choices)
+        public async Task<List<Flashcard>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool includeChoices)
         {
             IQueryable<Flashcard> query = _scholarmeDbContext.Set<Flashcard>().Where(f => f.FlashcardDeckId == flashcardDeckId);
 
-            if (choices)
+            if (includeChoices)
             {
                 query = query.Include(f => f.Choices);
             }

--- a/Repository/FlashcardInfo/IFlashcardRepository.cs
+++ b/Repository/FlashcardInfo/IFlashcardRepository.cs
@@ -5,7 +5,7 @@ namespace ScholarMeServer.Repository.FlashcardInfo
     public interface IFlashcardRepository
     {
         public Task AddFlashcard(Flashcard flashcard);
-        public Task<List<Flashcard>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool choices);
+        public Task<List<Flashcard>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool includeChoices);
         public Task<Flashcard?> GetFlashcardById(Guid flashcardId);
         public Task DeleteFlashcard(Flashcard flashcard);
         public Task SaveFlashcard(Flashcard flashcard);

--- a/Services/FlashcardDeckInfo/FlashcardDeckService.cs
+++ b/Services/FlashcardDeckInfo/FlashcardDeckService.cs
@@ -1,4 +1,6 @@
 ﻿using RestTest.Models;
+using ScholarMeServer.DTO.Flashcard;
+using ScholarMeServer.DTO.FlashcardChoice;
 using ScholarMeServer.DTO.FlashcardDeck;
 using ScholarMeServer.Repository.FlashcardDeckInfo;
 using ScholarMeServer.Utilities.Exceptions;
@@ -54,9 +56,9 @@ namespace ScholarMeServer.Services.FlashcardDeckInfo
             }).ToList();
         }
 
-        public async Task<FlashcardDeckReadOnlyDto> GetFlashcardDeckById(Guid flashcardDeckId)
+        public async Task<FlashcardDeckReadOnlyDto> GetFlashcardDeckById(Guid flashcardDeckId, bool includeFlashcards)
         {
-            var flashcardDeck = await _flashcardDeckRepository.GetFlashcardDeckById(flashcardDeckId);
+            var flashcardDeck = await _flashcardDeckRepository.GetFlashcardDeckById(flashcardDeckId, includeFlashcards);
 
             if (flashcardDeck == null)
             {
@@ -71,6 +73,15 @@ namespace ScholarMeServer.Services.FlashcardDeckInfo
                 Description = flashcardDeck.Description,
                 CreatedAt = flashcardDeck.CreatedAt,
                 UpdatedAt = flashcardDeck.UpdatedAt,
+                Flashcards = includeFlashcards ? flashcardDeck.Flashcards.Select(c => new FlashcardReadOnlyDto
+                {
+                    Id = c.Id,
+                    FlashcardSetId = null,
+                    Question = c.Question,
+                    CreatedAt = c.CreatedAt,
+                    UpdatedAt = c.UpdatedAt,
+                    Choices = null,
+                }).ToList() : null
             };
         }
 

--- a/Services/FlashcardDeckInfo/IFlashcardDeckService.cs
+++ b/Services/FlashcardDeckInfo/IFlashcardDeckService.cs
@@ -7,7 +7,7 @@ namespace ScholarMeServer.Services.FlashcardDeckInfo
         public Task<FlashcardDeckReadOnlyDto> CreateFlashcardDeck(Guid userAccountId, FlashcardDeckCreateDto flashcardDeckDto);
         public Task<List<FlashcardDeckReadOnlyDto>> GetFlashcardDecksByUserId(Guid userAccountId);
 
-        public Task<FlashcardDeckReadOnlyDto> GetFlashcardDeckById(Guid flashcardDeckId);
+        public Task<FlashcardDeckReadOnlyDto> GetFlashcardDeckById(Guid flashcardDeckId, bool includeFlashcards);
         public Task<FlashcardDeckReadOnlyDto> UpdateFlashcardDeck(Guid flashcardDeckId, FlashcardDeckUpdateDto flashcardDeckDto);
         public Task DeleteFlashcardDeck(Guid flashcardDeckId);
     }

--- a/Services/FlashcardInfo/FlashcardService.cs
+++ b/Services/FlashcardInfo/FlashcardService.cs
@@ -36,9 +36,9 @@ namespace ScholarMeServer.Services.FlashcardInfo
             };
         }
 
-        public async Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool choices)
+        public async Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool includeChoices)
         {
-            var flashcards = await _flashcardRepository.GetFlashcardsByDeckId(flashcardDeckId, choices);
+            var flashcards = await _flashcardRepository.GetFlashcardsByDeckId(flashcardDeckId, includeChoices);
 
             return flashcards.Select(f => new FlashcardReadOnlyDto
             {
@@ -47,7 +47,7 @@ namespace ScholarMeServer.Services.FlashcardInfo
                 Question = f.Question,
                 CreatedAt = f.CreatedAt,
                 UpdatedAt = f.UpdatedAt,
-                Choices = choices ? f.Choices.Select(c => new FlashcardChoiceReadOnlyDto
+                Choices = includeChoices ? f.Choices.Select(c => new FlashcardChoiceReadOnlyDto
                 {
                     Id = c.Id,
                     FlashcardId = null,

--- a/Services/FlashcardInfo/IFlashcardService.cs
+++ b/Services/FlashcardInfo/IFlashcardService.cs
@@ -5,7 +5,7 @@ namespace ScholarMeServer.Services.FlashcardInfo
     public interface IFlashcardService
     {
         public Task<FlashcardReadOnlyDto> CreateFlashcard(Guid flashcardDeckId, FlashcardCreateDto flashcardDto);
-        public Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool choices);
+        public Task<List<FlashcardReadOnlyDto>> GetFlashcardsByDeckId(Guid flashcardDeckId, bool includeChoices);
         public Task<FlashcardReadOnlyDto> GetFlashcardById(Guid flashcardId);
         public Task<FlashcardReadOnlyDto> UpdateFlashcard(Guid flashcardId, FlashcardUpdateDto flashcardDto);
         public Task DeleteFlashcard(Guid flashcardId);


### PR DESCRIPTION
Updated `GetFlashcardDeckById` and `GetFlashcardsByDeckId` methods to include optional parameters (`includeFlashcards` and `includeChoices`) for more flexible API responses. Renamed `choices` to `includeChoices` for clarity. Made properties nullable and conditionally ignored in DTOs to optimize payload size. Updated interfaces and services to reflect new method signatures, enhancing functionality and flexibility of the API.